### PR TITLE
fixed CSS styling for individual group in group list

### DIFF
--- a/Client/src/components/Home/IndividualGroupInGroupList.jsx
+++ b/Client/src/components/Home/IndividualGroupInGroupList.jsx
@@ -4,11 +4,9 @@ import axios from 'axios';
 function IndividualGroupInGroupList ({ group }) {
   return (
     <>
-      <div className='grid grid-cols-10'>
-        <div className='w-20'>
-          <img className='object-scale-down' src={group.pictureurl} alt={group.name}></img>
-        </div>
-        <div className='col-span-9 text-left'>
+      <div className='flex'>
+          <img className='object-scale-down h-20 m-1' src={group.pictureurl} alt={group.name}></img>
+        <div className='flex flex-col p-3'>
           <div className='font-bold'>
             {group.name}
           </div>


### PR DESCRIPTION
Dear Team Saffron,

After getting a good night's rest and reviewing the code in IndividualInGroupList, I could not help but notice the overlapping of divs when making the screen size smaller. To combat this, I have fixed the elements to use flex and flex columns. (thx AD I looked at your code)

Sincerely,
Huong